### PR TITLE
Replace deprecated urls function with re_path

### DIFF
--- a/directory/urls.py
+++ b/directory/urls.py
@@ -1,11 +1,8 @@
 """Copyright Askbot SpA 2014, Licensed under GPLv3 license."""
-try:
-    from django.conf.urls import url
-except ImportError:
-    from django.conf.urls.defaults import url
 
 from directory import views
+from django.urls import re_path
 
 urlpatterns = (
-    url(r'^(?P<path>.*)$', views.browse, name='directory_browse'),
+    re_path(r'^(?P<path>.*)$', views.browse, name='directory_browse'),
 )


### PR DESCRIPTION
The `url` function has been deprecated in Django since `3.0` and is entirely removed in `4.0`

`url` was an alias to `django.urls.re_path` anyway and has existed in Django since `2.0` and the last supported `2.x` version (`2.2`) ended in April 2022.

This should allow this package to work with all supported versions of Django, and all unsupported versions >= `2.0`.